### PR TITLE
RDKVREFPLT-2987: Add vendor-cpc build target support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+cmake_minimum_required(VERSION 3.0)
+
+set(PROJECTLIBNAME "vendor-cpc")
+
+project(${PROJECTLIBNAME} VERSION 1.0.0 DESCRIPTION "Vendor CPC Library - Dummy" LANGUAGES CXX)
+
+if(NOT CMAKE_BUILD_TYPE)
+    message(STATUS "No build type selected, default to Release")
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/")
+
+find_package(PkgConfig REQUIRED)
+find_package(IARMBus REQUIRED)
+
+pkg_check_modules(GLIB REQUIRED glib-2.0)
+pkg_check_modules(SAFEC REQUIRED libsafec)
+
+include_directories(${GLIB_INCLUDE_DIRS} ${IARMBUS_INCLUDE_DIRS} ${SAFEC_INCLUDE_DIRS})
+
+include(GNUInstallDirs)
+
+set(SOURCE_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/ctrlm_vendor_network_factory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ctrlm_rf4ce_voice_packet_analysis.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/irdb/ctrlm_irdb_factory.cpp
+)
+
+add_library(${PROJECTLIBNAME} STATIC ${SOURCE_FILES})
+target_link_libraries(${PROJECTLIBNAME} ${GLIB_LIBRARIES} ${SAFEC_LIBRARIES})
+target_compile_options(${PROJECTLIBNAME} PRIVATE ${GLIB_CFLAGS_OTHER} ${SAFEC_CFLAGS_OTHER})
+
+set_target_properties(${PROJECTLIBNAME} PROPERTIES
+    VERSION ${PROJECT_VERSION}
+)
+
+install(TARGETS ${PROJECTLIBNAME}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 cmake_minimum_required(VERSION 3.0)
 
-set(PROJECTLIBNAME "vendor-cpc")
+set(PROJECTLIBNAME "ctrlm-cpc")
 set(MAJOR_VERSION 1)
 set(MINOR_VERSION 0)
 set(PROJECT_VERSION "${MAJOR_VERSION}.${MINOR_VERSION}.0")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,13 +2,18 @@
 cmake_minimum_required(VERSION 3.0)
 
 set(PROJECTLIBNAME "vendor-cpc")
+set(MAJOR_VERSION 1)
+set(MINOR_VERSION 0)
+set(PROJECT_VERSION "${MAJOR_VERSION}.${MINOR_VERSION}.0")
 
-project(${PROJECTLIBNAME} VERSION 1.0.0 DESCRIPTION "Vendor CPC Library - Dummy" LANGUAGES CXX)
+project(${PROJECTLIBNAME} VERSION ${PROJECT_VERSION} DESCRIPTION "Vendor CPC Library - Dummy" LANGUAGES CXX)
 
 if(NOT CMAKE_BUILD_TYPE)
     message(STATUS "No build type selected, default to Release")
     set(CMAKE_BUILD_TYPE Release)
 endif()
+
+option(CREATE_SHARED_LIB "Create shared library" ON)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/")
 
@@ -28,12 +33,18 @@ set(SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/irdb/ctrlm_irdb_factory.cpp
 )
 
-add_library(${PROJECTLIBNAME} STATIC ${SOURCE_FILES})
+if(CREATE_SHARED_LIB)
+    add_library(${PROJECTLIBNAME} SHARED ${SOURCE_FILES})
+else()
+    add_library(${PROJECTLIBNAME} STATIC ${SOURCE_FILES})
+endif()
+
 target_link_libraries(${PROJECTLIBNAME} ${GLIB_LIBRARIES} ${SAFEC_LIBRARIES})
 target_compile_options(${PROJECTLIBNAME} PRIVATE ${GLIB_CFLAGS_OTHER} ${SAFEC_CFLAGS_OTHER})
 
 set_target_properties(${PROJECTLIBNAME} PROPERTIES
     VERSION ${PROJECT_VERSION}
+    SOVERSION ${MAJOR_VERSION}
 )
 
 install(TARGETS ${PROJECTLIBNAME}

--- a/cmake/FindIARMBus.cmake
+++ b/cmake/FindIARMBus.cmake
@@ -1,0 +1,41 @@
+# If not stated otherwise in this file or this component's license file the
+# following copyright and licenses apply:
+#
+# Copyright 2020 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# - Try to find IARMBus
+# Once done this will define
+#  IARMBUS_FOUND - System has IARMBus
+#  IARMBUS_INCLUDE_DIRS - The IARMBus include directories
+#  IARMBUS_LIBRARIES - The libraries needed to use IARMBus
+#  IARMBUS_FLAGS - The flags needed to use IARMBus
+#
+
+find_package(PkgConfig)
+
+find_library(IARMBUS_LIBRARIES NAMES IARMBus)
+find_path(IARMBUS_INCLUDE_DIRS NAMES libIARM.h PATH_SUFFIXES rdk/iarmbus)
+
+set(IARMBUS_LIBRARIES ${IARMBUS_LIBRARIES} CACHE PATH "Path to IARMBus library")
+set(IARMBUS_INCLUDE_DIRS ${IARMBUS_INCLUDE_DIRS} CACHE PATH "Path to IARMBus include")
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(IARMBUS DEFAULT_MSG IARMBUS_INCLUDE_DIRS IARMBUS_LIBRARIES)
+
+mark_as_advanced(
+    IARMBUS_FOUND
+    IARMBUS_INCLUDE_DIRS
+    IARMBUS_LIBRARIES)
+

--- a/ctrlm_rf4ce_voice_packet_analysis.cpp
+++ b/ctrlm_rf4ce_voice_packet_analysis.cpp
@@ -17,7 +17,8 @@
  * limitations under the License.
 */
 
-#include "../ctrlm_voice_packet_analysis.h"
+#include <glib.h>
+#include "ctrlm_private/ctrlm_voice_packet_analysis.h"
 
 #define SEQUENCE_NUM_INVALID  (0xFF)
 

--- a/ctrlm_vendor_network_factory.cpp
+++ b/ctrlm_vendor_network_factory.cpp
@@ -18,8 +18,8 @@
 */
 #include <glib.h>
 #include <vector>
-#include "ctrlm_vendor_network_factory.h"
-#include "ctrlm_log.h"
+#include "ctrlm_private/ctrlm_vendor_network_factory.h"
+#include "ctrlm_private/ctrlm_log.h"
 
 // vector contains vendor's network factory functions
 // vector is declared as pointer, because vendor's network factory initializers objects
@@ -48,7 +48,7 @@ void ctrlm_vendor_network_factory_func_add(ctrlm_vendor_network_factory_func_t* 
 
 // by the time of this function call, ctrlm_vendor_network_factory_func_chain will be initialized with
 // vendor factory functions
-int ctrlm_vendor_network_factory(unsigned long ignore_mask, json_t *json_config_root, networks_map_t& networks) {
+int ctrlm_vendor_network_factory(vendor_network_opts_t *ignore_mask, json_t *json_config_root, networks_map_t& networks) {
   if (0 == ctrlm_vendor_network_factory_func_chain){
     return 0;
   }

--- a/irdb/ctrlm_irdb_factory.cpp
+++ b/irdb/ctrlm_irdb_factory.cpp
@@ -17,14 +17,14 @@
  * limitations under the License.
 */
 
-#include "ctrlm_irdb_factory.h"
-#include "ctrlm_irdb_stub.h"
+#include "ctrlm_private/ctrlm_irdb_factory.h"
+#include "ctrlm_private/ctrlm_irdb_stub.h"
 
-ctrlm_irdb_t *ctrlm_irdb_create() {
+ctrlm_irdb_t *ctrlm_irdb_create(bool platform_tv) {
     ctrlm_irdb_t *ret = NULL;
 
     if(ret == NULL) {
-        ret = new ctrlm_irdb_stub_t(CTRLM_IRDB_MODE_OFFLINE);
+        ret = new ctrlm_irdb_stub_t(CTRLM_IRDB_MODE_OFFLINE, platform_tv);
     }
 
     return(ret);


### PR DESCRIPTION
Modify the source to generate vendor-cpc library with CMake support
Fix the build errors to match RDK-E MW 1.9.2